### PR TITLE
Add Jekyll/kramdown GitHub Pages frontend with decoupled CSS

### DIFF
--- a/Monitoring.md
+++ b/Monitoring.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Monitoring Tools
+---
+
 # Monitoring Tools
 
 Below is a list of some tools which can be used to monitor your network

--- a/Monitoring.md
+++ b/Monitoring.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Monitoring Tools
-permalink: /Monitoring.html
+permalink: /monitoring.html
 ---
 
 # Monitoring Tools

--- a/Monitoring.md
+++ b/Monitoring.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Monitoring Tools
+permalink: /Monitoring.html
 ---
 
 # Monitoring Tools

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Manifesto
+---
+
 # Manifesto
 
 Network Engineers Manifesto 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Manifesto
+permalink: /
 ---
 
 # Manifesto

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,16 @@
+title: Network Engineers Manifesto
+description: A living document for network engineering excellence
+baseurl: "/Manifesto"
+url: "https://jandahl.github.io"
+
+markdown: kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false
+
+plugins:
+  - jekyll-relative-links
+
+relative_links:
+  enabled: true
+  collections: false

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page.title }} — Network Engineers</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=IBM+Plex+Sans:wght@300;400;500;600&family=IBM+Plex+Serif:ital,wght@0,300;0,400;0,600;1,300&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+</head>
+<body>
+
+<nav>
+    <div class="nav-inner">
+        <a class="nav-brand" href="{{ '/' | relative_url }}">Network Engineers</a>
+        <ul class="nav-links">
+            <li><a href="{{ '/' | relative_url }}"{% if page.url == '/' %} class="active"{% endif %}>Manifesto</a></li>
+            <li><a href="{{ '/Monitoring.html' | relative_url }}"{% if page.url contains 'Monitoring' %} class="active"{% endif %}>Monitoring Tools</a></li>
+        </ul>
+    </div>
+</nav>
+
+<main class="content">
+    {{ content }}
+</main>
+
+<footer>
+    <p>Network Engineers Manifesto &mdash; A living document</p>
+</footer>
+
+</body>
+</html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
     <title>{% if page.title %}{{ page.title }} — {% endif %}{{ site.title }}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=IBM+Plex+Sans:wght@300;400;500;600&family=IBM+Plex+Serif:ital,wght@0,300;0,400;0,600;1,300&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=IBM+Plex+Sans:wght@400;500&family=IBM+Plex+Serif:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
 </head>
 <body class="page-{{ page.title | slugify }}">
@@ -15,8 +15,8 @@
     <div class="nav-inner">
         <a class="nav-brand" href="{{ '/' | relative_url }}">Network Engineers</a>
         <ul class="nav-links">
-            <li><a href="{{ '/' | relative_url }}"{% if page.path == 'README.md' %} class="active" aria-current="page"{% endif %}>Manifesto</a></li>
-            <li><a href="{{ '/monitoring.html' | relative_url }}"{% if page.path == 'Monitoring.md' %} class="active" aria-current="page"{% endif %}>Monitoring Tools</a></li>
+            <li><a href="{{ '/' | relative_url }}"{% if page.url == '/' %} class="active" aria-current="page"{% endif %}>Manifesto</a></li>
+            <li><a href="{{ '/monitoring.html' | relative_url }}"{% if page.url == '/monitoring.html' %} class="active" aria-current="page"{% endif %}>Monitoring Tools</a></li>
         </ul>
     </div>
 </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
     <div class="nav-inner">
         <a class="nav-brand" href="{{ '/' | relative_url }}">Network Engineers</a>
         <ul class="nav-links">
-            <li><a href="{{ '/' | relative_url }}"{% if page.url == '/' %} class="active"{% endif %}>Manifesto</a></li>
+            <li><a href="{{ '/' | relative_url }}"{% if page.url == '/' or page.url == '/index.html' %} class="active"{% endif %}>Manifesto</a></li>
             <li><a href="{{ '/Monitoring.html' | relative_url }}"{% if page.url contains 'Monitoring' %} class="active"{% endif %}>Monitoring Tools</a></li>
         </ul>
     </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,8 +15,8 @@
     <div class="nav-inner">
         <a class="nav-brand" href="{{ '/' | relative_url }}">Network Engineers</a>
         <ul class="nav-links">
-            <li><a href="{{ '/' | relative_url }}"{% if page.url == '/' or page.url == '/index.html' %} class="active"{% endif %}>Manifesto</a></li>
-            <li><a href="{{ '/Monitoring.html' | relative_url }}"{% if page.url contains 'Monitoring' %} class="active"{% endif %}>Monitoring Tools</a></li>
+            <li><a href="{{ '/' | relative_url }}"{% if page.url == '/' or page.url == '/index.html' %} class="active" aria-current="page"{% endif %}>Manifesto</a></li>
+            <li><a href="{{ '/Monitoring.html' | relative_url }}"{% if page.url == '/Monitoring.html' %} class="active" aria-current="page"{% endif %}>Monitoring Tools</a></li>
         </ul>
     </div>
 </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,20 +3,20 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ page.title }} — Network Engineers</title>
+    <title>{% if page.title %}{{ page.title }} — {% endif %}{{ site.title }}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=IBM+Plex+Sans:wght@300;400;500;600&family=IBM+Plex+Serif:ital,wght@0,300;0,400;0,600;1,300&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
 </head>
-<body>
+<body class="page-{{ page.title | slugify }}">
 
 <nav>
     <div class="nav-inner">
         <a class="nav-brand" href="{{ '/' | relative_url }}">Network Engineers</a>
         <ul class="nav-links">
-            <li><a href="{{ '/' | relative_url }}"{% if page.url == '/' or page.url == '/index.html' %} class="active" aria-current="page"{% endif %}>Manifesto</a></li>
-            <li><a href="{{ '/Monitoring.html' | relative_url }}"{% if page.url == '/Monitoring.html' %} class="active" aria-current="page"{% endif %}>Monitoring Tools</a></li>
+            <li><a href="{{ '/' | relative_url }}"{% if page.path == 'README.md' %} class="active" aria-current="page"{% endif %}>Manifesto</a></li>
+            <li><a href="{{ '/monitoring.html' | relative_url }}"{% if page.path == 'Monitoring.md' %} class="active" aria-current="page"{% endif %}>Monitoring Tools</a></li>
         </ul>
     </div>
 </nav>
@@ -26,7 +26,7 @@
 </main>
 
 <footer>
-    <p>Network Engineers Manifesto &mdash; A living document</p>
+    <p>{{ site.title }} &mdash; {{ site.description }}</p>
 </footer>
 
 </body>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -43,8 +43,8 @@ nav {
     top: 0;
     z-index: 100;
     background: rgba(250, 250, 248, 0.90);
-    backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);
+    backdrop-filter: blur(16px);
     border-bottom: 1px solid var(--border);
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -13,7 +13,7 @@
     --bg:           #FAFAF8;
     --surface:      #FFFFFF;
     --text:         #1C1C1E;
-    --text-muted:   #6B7280;
+    --text-muted:   #4B5563;
     --heading:      #0A0A0A;
     --accent:       #0F62FE;
     --accent-bg:    #EEF4FF;
@@ -34,6 +34,7 @@ body {
     font-size: 16px;
     line-height: 1.7;
     -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 /* ── Navigation ──────────────────────────── */
@@ -114,8 +115,8 @@ nav {
     border-bottom: 1px solid var(--border);
 }
 
-/* Subtitle paragraph immediately after h1 */
-.content h1 + p {
+/* Subtitle paragraph immediately after h1 — manifesto page only */
+.page-manifesto .content h1 + p {
     font-family: 'IBM Plex Mono', monospace;
     font-size: 0.7rem;
     letter-spacing: 0.2em;
@@ -137,7 +138,7 @@ nav {
     border-top: 1px solid var(--border-light);
 }
 
-.content h2:first-of-type {
+.content > *:first-child {
     border-top: none;
     padding-top: 0;
     margin-top: 0;
@@ -157,8 +158,8 @@ nav {
 }
 
 /* first h3 / h2 gets no top border — it follows the subtitle */
-.content h1 + p + h3,
-.content h1 + p + h2,
+.page-manifesto .content h1 + p + h3,
+.page-manifesto .content h1 + p + h2,
 .content h1 + h3,
 .content h1 + h2 {
     border-top: none;
@@ -199,7 +200,7 @@ nav {
     content: '';
     position: absolute;
     left: 0;
-    top: 1.1rem;
+    top: 0.8em;
     width: 5px;
     height: 5px;
     border-radius: 50%;
@@ -226,7 +227,7 @@ nav {
     left: 0;
     top: 0.25rem;
     background: none;
-    color: var(--border);
+    color: var(--text-muted);
     width: auto;
     height: auto;
     border-radius: 0;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -21,8 +21,10 @@
     --border-light: #F0EDE8;
 }
 
-html {
-    scroll-behavior: smooth;
+@media (prefers-reduced-motion: no-preference) {
+    html {
+        scroll-behavior: smooth;
+    }
 }
 
 body {
@@ -219,7 +221,7 @@ nav {
 }
 
 .content ul li > ul li::before {
-    content: '–';
+    content: '\2013';
     position: absolute;
     left: 0;
     top: 0.25rem;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,280 @@
+/* ─────────────────────────────────────────
+   Network Engineers Manifesto — stylesheet
+   Font: IBM Plex Serif / Sans / Mono
+   ───────────────────────────────────────── */
+
+*, *::before, *::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+:root {
+    --bg:           #FAFAF8;
+    --surface:      #FFFFFF;
+    --text:         #1C1C1E;
+    --text-muted:   #6B7280;
+    --heading:      #0A0A0A;
+    --accent:       #0F62FE;
+    --accent-bg:    #EEF4FF;
+    --border:       #E5E2DC;
+    --border-light: #F0EDE8;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'IBM Plex Sans', system-ui, sans-serif;
+    font-size: 16px;
+    line-height: 1.7;
+    -webkit-font-smoothing: antialiased;
+}
+
+/* ── Navigation ──────────────────────────── */
+
+nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: rgba(250, 250, 248, 0.90);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-bottom: 1px solid var(--border);
+}
+
+.nav-inner {
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 0 2rem;
+    height: 52px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.nav-brand {
+    font-family: 'IBM Plex Serif', serif;
+    font-weight: 400;
+    font-size: 0.875rem;
+    color: var(--heading);
+    text-decoration: none;
+    letter-spacing: 0.01em;
+}
+
+.nav-links {
+    display: flex;
+    gap: 0.25rem;
+    list-style: none;
+}
+
+.nav-links a {
+    display: block;
+    padding: 0.3rem 0.65rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    text-decoration: none;
+    border-radius: 3px;
+    transition: color 0.15s, background 0.15s;
+}
+
+.nav-links a:hover,
+.nav-links a.active {
+    color: var(--accent);
+    background: var(--accent-bg);
+}
+
+/* ── Content area ────────────────────────── */
+
+.content {
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 4.5rem 2rem 6rem;
+}
+
+/* ── Headings ────────────────────────────── */
+
+.content h1 {
+    font-family: 'IBM Plex Serif', serif;
+    font-weight: 300;
+    font-size: clamp(3rem, 8vw, 6.5rem);
+    line-height: 1.02;
+    letter-spacing: -0.03em;
+    color: var(--heading);
+    margin-bottom: 0.5rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--border);
+}
+
+/* Subtitle paragraph immediately after h1 */
+.content h1 + p {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.7rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-top: 1.25rem;
+    margin-bottom: 2.5rem;
+}
+
+.content h2 {
+    font-family: 'IBM Plex Serif', serif;
+    font-weight: 600;
+    font-size: 1.375rem;
+    color: var(--heading);
+    letter-spacing: -0.01em;
+    margin-top: 3rem;
+    margin-bottom: 0.875rem;
+    padding-top: 3rem;
+    border-top: 1px solid var(--border-light);
+}
+
+.content h2:first-of-type {
+    border-top: none;
+    padding-top: 0;
+    margin-top: 0;
+}
+
+/* h3 used as major section headings in README */
+.content h3 {
+    font-family: 'IBM Plex Serif', serif;
+    font-weight: 600;
+    font-size: 1.25rem;
+    color: var(--heading);
+    letter-spacing: -0.01em;
+    margin-top: 3rem;
+    margin-bottom: 0.875rem;
+    padding-top: 2.5rem;
+    border-top: 1px solid var(--border-light);
+}
+
+/* first h3 / h2 gets no top border — it follows the subtitle */
+.content h1 + p + h3,
+.content h1 + p + h2,
+.content h1 + h3,
+.content h1 + h2 {
+    border-top: none;
+    padding-top: 0;
+    margin-top: 1rem;
+}
+
+/* ── Body text ───────────────────────────── */
+
+.content p {
+    font-size: 0.9375rem;
+    color: var(--text);
+    margin-bottom: 1rem;
+    max-width: 65ch;
+}
+
+/* ── Lists ───────────────────────────────── */
+
+.content ul {
+    list-style: none;
+    padding: 0;
+    margin-bottom: 0.5rem;
+}
+
+.content ul li {
+    display: flex;
+    gap: 0.875rem;
+    align-items: flex-start;
+    padding: 0.55rem 0;
+    font-size: 0.9375rem;
+    color: var(--text);
+    border-bottom: 1px solid var(--border-light);
+}
+
+.content ul li:last-child {
+    border-bottom: none;
+}
+
+.content ul li::before {
+    content: '';
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--accent);
+    flex-shrink: 0;
+    margin-top: 0.6rem;
+}
+
+/* Nested lists */
+.content ul li > ul {
+    margin-top: 0.5rem;
+    margin-bottom: 0;
+    padding-left: 0.25rem;
+}
+
+.content ul li > ul li {
+    font-size: 0.875rem;
+    color: var(--text-muted);
+    border-bottom: none;
+    padding: 0.2rem 0;
+}
+
+.content ul li > ul li::before {
+    content: '–';
+    background: none;
+    color: var(--border);
+    width: auto;
+    height: auto;
+    margin-top: 0;
+    font-size: 0.8rem;
+}
+
+/* ── Inline code ─────────────────────────── */
+
+.content code {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.83em;
+    background: var(--accent-bg);
+    color: var(--accent);
+    padding: 0.1em 0.45em;
+    border-radius: 3px;
+}
+
+/* ── Links ───────────────────────────────── */
+
+.content a {
+    color: var(--accent);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: border-color 0.15s;
+}
+
+.content a:hover {
+    border-bottom-color: var(--accent);
+}
+
+/* Links inside list items — no border treatment */
+.content li a {
+    font-weight: 500;
+}
+
+/* ── Footer ──────────────────────────────── */
+
+footer {
+    border-top: 1px solid var(--border);
+    padding: 2.25rem 2rem;
+    text-align: center;
+}
+
+footer p {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    letter-spacing: 0.03em;
+}
+
+/* ── Responsive ──────────────────────────── */
+
+@media (max-width: 680px) {
+    .nav-links { display: none; }
+    .content { padding: 3rem 1.5rem 4rem; }
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -11,6 +11,7 @@
 
 :root {
     --bg:           #FAFAF8;
+    --bg-rgb:       250, 250, 248;
     --surface:      #FFFFFF;
     --text:         #1C1C1E;
     --text-muted:   #4B5563;
@@ -43,7 +44,7 @@ nav {
     position: sticky;
     top: 0;
     z-index: 100;
-    background: rgba(250, 250, 248, 0.90);
+    background: rgba(var(--bg-rgb), 0.90);
     -webkit-backdrop-filter: blur(16px);
     backdrop-filter: blur(16px);
     border-bottom: 1px solid var(--border);
@@ -158,8 +159,8 @@ nav {
 }
 
 /* first h3 / h2 gets no top border — it follows the subtitle */
-.page-manifesto .content h1 + p + h3,
-.page-manifesto .content h1 + p + h2,
+.content h1 + p + h3,
+.content h1 + p + h2,
 .content h1 + h3,
 .content h1 + h2 {
     border-top: none;
@@ -286,5 +287,7 @@ footer p {
         padding: 0.75rem 1rem;
         gap: 0.5rem;
     }
+    .nav-links { gap: 0.5rem; }
+    .nav-links a { padding: 0.5rem 0.75rem; }
     .content { padding: 3rem 1.5rem 4rem; }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -182,10 +182,8 @@ nav {
 }
 
 .content ul li {
-    display: flex;
-    gap: 0.875rem;
-    align-items: flex-start;
-    padding: 0.55rem 0;
+    position: relative;
+    padding: 0.55rem 0 0.55rem 1.25rem;
     font-size: 0.9375rem;
     color: var(--text);
     border-bottom: 1px solid var(--border-light);
@@ -197,12 +195,13 @@ nav {
 
 .content ul li::before {
     content: '';
+    position: absolute;
+    left: 0;
+    top: 1.1rem;
     width: 5px;
     height: 5px;
     border-radius: 50%;
     background: var(--accent);
-    flex-shrink: 0;
-    margin-top: 0.6rem;
 }
 
 /* Nested lists */
@@ -216,16 +215,19 @@ nav {
     font-size: 0.875rem;
     color: var(--text-muted);
     border-bottom: none;
-    padding: 0.2rem 0;
+    padding: 0.2rem 0 0.2rem 1rem;
 }
 
 .content ul li > ul li::before {
     content: '–';
+    position: absolute;
+    left: 0;
+    top: 0.25rem;
     background: none;
     color: var(--border);
     width: auto;
     height: auto;
-    margin-top: 0;
+    border-radius: 0;
     font-size: 0.8rem;
 }
 
@@ -275,6 +277,11 @@ footer p {
 /* ── Responsive ──────────────────────────── */
 
 @media (max-width: 680px) {
-    .nav-links { display: none; }
+    .nav-inner {
+        flex-direction: column;
+        height: auto;
+        padding: 0.75rem 1rem;
+        gap: 0.5rem;
+    }
     .content { padding: 3rem 1.5rem 4rem; }
 }


### PR DESCRIPTION
## Summary

- **Dynamic conversion** via Jekyll/kramdown — the existing `.md` files are rendered at build time, no static HTML export
- **Decoupled CSS** in `assets/css/style.css` (IBM Plex Serif/Sans/Mono typography, CSS custom properties for easy theming) — edit styles without touching markup or content
- **Minimal layout template** in `_layouts/default.html` — sticky nav linking between both pages, content slot, footer
- **Front matter only** added to `README.md` and `Monitoring.md` — content itself is unchanged

## Files

| File | Purpose |
|---|---|
| `_config.yml` | Jekyll config: kramdown + GFM input, `jekyll-relative-links` plugin |
| `_layouts/default.html` | HTML shell — nav, `{{ content }}` slot, footer |
| `assets/css/style.css` | All typography and design — edit freely without touching layout |
| `README.md` / `Monitoring.md` | Front matter (`layout: default`, `title:`) added at top |

## Enabling GitHub Pages

1. Merge this PR into `master`
2. Go to **Settings → Pages**
3. Set source → branch `master`, folder `/ (root)`
4. Site will build automatically at `https://jandahl.github.io/Manifesto/`

## Test plan

- [ ] GitHub Actions build passes (Jekyll build step)
- [ ] `index.html` renders the manifesto with large display title and section headings
- [ ] `Monitoring.html` renders with h2 category headers and linked tool names
- [ ] Nav active state highlights correctly on each page
- [ ] Mobile layout (≤680px) — nav collapses, content readable
- [ ] Tweak a colour in `style.css` and confirm it propagates with no layout changes needed

https://claude.ai/code/session_01Nh1MNNX5UqYgtCGTbhFsbq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nh1MNNX5UqYgtCGTbhFsbq)_